### PR TITLE
[#5] 테마 초기화로 인한 SSR/SEO 렌더링 문제 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,18 @@ export const metadata: Metadata = {
   description: 'Fantajin의 개발 블로그입니다.',
 }
 
+const themeInitScript = `
+  try {
+    const savedTheme = localStorage.getItem('theme')
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+    document.body.setAttribute('data-theme', savedTheme || systemTheme)
+  } catch (error) {
+    document.body.setAttribute('data-theme', 'light')
+  }
+`
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -31,7 +43,12 @@ export default function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
         />
       </head>
-      <body className={`${geistMono.variable} font-pretendard antialiased`}>
+      <body
+        data-theme="light"
+        suppressHydrationWarning
+        className={`${geistMono.variable} font-pretendard antialiased`}
+      >
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <ThemeProvider>
           <Providers>
             <Header />

--- a/src/_app/providers/ThemeContext.tsx
+++ b/src/_app/providers/ThemeContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
 type Theme = 'light' | 'dark'
+const THEME_STORAGE_KEY = 'theme'
 
 interface ThemeContextType {
   theme: Theme
@@ -13,45 +14,43 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>('light')
-  const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    // 컴포넌트가 마운트된 후에만 실행
-    setMounted(true)
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+    const activeTheme =
+      document.body.getAttribute('data-theme') === 'dark'
+        ? 'dark'
+        : savedTheme || systemTheme
 
-    // 로컬 스토리지에서 테마 가져오기
-    const savedTheme = localStorage.getItem('theme') as Theme | null
-
-    let activeTheme: Theme
-
-    if (savedTheme) {
-      activeTheme = savedTheme
-    } else {
-      // 시스템 설정 확인
-      const prefersDark = window.matchMedia(
-        '(prefers-color-scheme: dark)',
-      ).matches
-      activeTheme = prefersDark ? 'dark' : 'light'
-    }
-
-    console.log('activeTheme', activeTheme)
-
-    // 테마 적용
     document.body.setAttribute('data-theme', activeTheme)
     setTheme(activeTheme)
-    localStorage.setItem('theme', activeTheme)
+
+    if (savedTheme) {
+      return
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const syncSystemTheme = (event: MediaQueryListEvent) => {
+      const nextTheme = event.matches ? 'dark' : 'light'
+      document.body.setAttribute('data-theme', nextTheme)
+      setTheme(nextTheme)
+    }
+
+    mediaQuery.addEventListener('change', syncSystemTheme)
+
+    return () => {
+      mediaQuery.removeEventListener('change', syncSystemTheme)
+    }
   }, [])
 
   const toggleTheme = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light'
     setTheme(newTheme)
     document.body.setAttribute('data-theme', newTheme)
-    localStorage.setItem('theme', newTheme)
-  }
-
-  // 마운트되기 전에는 아무것도 렌더링하지 않음 (hydration 오류 방지)
-  if (!mounted) {
-    return null
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme)
   }
 
   return (


### PR DESCRIPTION
## 작업 내용
- ThemeProvider가 마운트 전까지 `null`을 반환하지 않도록 수정했습니다.
- 초기 렌더 직후 `body[data-theme]`를 맞추는 스크립트를 추가해 SSR 본문 렌더링을 유지했습니다.
- 저장된 테마와 시스템 테마 동기화 로직을 정리하고 디버그 로그를 제거했습니다.

## 확인 내용
- npm run build
- 초기 HTML 응답에 실제 홈 콘텐츠가 포함되는지 확인
- 최신 main(next-mdx-remote 6.0.0 반영) 기준으로 rebase 후 재검증

## 관련 이슈
- close #5
