### PR TITLE
[#6] 깨진 내비게이션 링크와 카테고리 경로 정리

### DIFF
--- a/app/life/page.tsx
+++ b/app/life/page.tsx
@@ -1,0 +1,5 @@
+import LifePage from '@/src/screens/life/Life'
+
+export default function Life() {
+  return <LifePage />
+}

--- a/src/entities/category/model/category.ts
+++ b/src/entities/category/model/category.ts
@@ -1,4 +1,5 @@
 import { CategoryProps } from '../../post/model/types'
+import { SITE_PATHS } from '@/src/shared/config/routes'
 
 export const categories: CategoryProps[] = [
   {
@@ -6,7 +7,7 @@ export const categories: CategoryProps[] = [
     title: '내 소개',
     description: '개발자 소개 및 이력',
     icon: null, // 아이콘은 BlogPage에서 import해서 할당
-    href: '/about',
+    href: SITE_PATHS.about,
     color: 'from-green-500/20 to-green-700/20',
   },
   {
@@ -14,7 +15,7 @@ export const categories: CategoryProps[] = [
     title: '개발',
     description: '프로그래밍 및 개발 관련 글',
     icon: null,
-    href: '', // 나중에 BlogPage에서 동적으로 할당
+    href: SITE_PATHS.developmentTag,
     color: 'from-blue-500/20 to-blue-700/20',
   },
   {
@@ -22,7 +23,7 @@ export const categories: CategoryProps[] = [
     title: '잡담',
     description: '재테크 및 생각 정리',
     icon: null,
-    href: '/life',
+    href: SITE_PATHS.life,
     color: 'from-yellow-500/20 to-yellow-700/20',
   },
 ]

--- a/src/screens/life/Life.tsx
+++ b/src/screens/life/Life.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link'
+import { Card, CardContent } from '@/src/shared/ui/Card'
+import { SITE_PATHS } from '@/src/shared/config/routes'
+
+const upcomingTopics = [
+  '개발자 커리어와 일하는 방식',
+  '회고, 책, 일상에서 얻은 배움',
+  '재테크와 생활 루틴 정리',
+]
+
+export default function LifePage() {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <Card className="bg-cardColor/90 shadow-lg">
+        <CardContent className="p-8">
+          <div className="mb-10">
+            <p className="mb-3 text-sm font-semibold tracking-[0.2em] text-gray-500 uppercase">
+              Life
+            </p>
+            <h1 className="mb-4 text-3xl font-bold">잡담과 생각을 모아둘 공간</h1>
+            <p className="max-w-3xl leading-relaxed text-gray-400">
+              이 공간에는 기술 글보다 조금 더 가벼운 기록을 쌓아갈 예정입니다.
+              커리어에서 배운 점, 생활 루틴, 재테크와 회고처럼 시간이 지나도
+              다시 꺼내보고 싶은 메모를 천천히 모아두겠습니다.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card className="bg-backgroundColor/50 h-full">
+              <CardContent className="h-full p-6">
+                <h2 className="mb-4 text-xl font-semibold">곧 다룰 이야기</h2>
+                <ul className="space-y-3 text-gray-400">
+                  {upcomingTopics.map((topic) => (
+                    <li key={topic} className="flex items-start gap-3">
+                      <span className="mt-2 h-2 w-2 rounded-full bg-blue-400" />
+                      <span>{topic}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card className="bg-backgroundColor/50 h-full">
+              <CardContent className="flex h-full flex-col gap-4 p-6">
+                <h2 className="text-xl font-semibold">둘러보기</h2>
+                <p className="leading-relaxed text-gray-400">
+                  아직 잡담 글이 많지 않아서, 우선은 블로그 메인과 태그 페이지에서
+                  현재 글들을 더 둘러볼 수 있게 연결해두었습니다.
+                </p>
+                <div className="mt-auto flex flex-wrap gap-3">
+                  <Link
+                    href={SITE_PATHS.home}
+                    className="tag-border rounded-lg px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-100/10"
+                  >
+                    블로그 메인 보기
+                  </Link>
+                  <Link
+                    href={SITE_PATHS.tags}
+                    className="tag-border rounded-lg px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-100/10"
+                  >
+                    태그 전체 보기
+                  </Link>
+                  <Link
+                    href={SITE_PATHS.about}
+                    className="tag-border rounded-lg px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-100/10"
+                  >
+                    소개 페이지 보기
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -1,0 +1,8 @@
+export const SITE_PATHS = {
+  home: '/',
+  blog: '/blog',
+  about: '/about',
+  life: '/life',
+  tags: '/tags',
+  developmentTag: `/tags/${encodeURIComponent('개발')}`,
+} as const

--- a/src/widget/header/config/HeaderList.ts
+++ b/src/widget/header/config/HeaderList.ts
@@ -1,3 +1,5 @@
+import { SITE_PATHS } from '@/src/shared/config/routes'
+
 /**
  * @description Header Tab List
  */
@@ -6,22 +8,22 @@ export const HEADER_TAB_LIST = [
   {
     id: 1,
     title: 'Blog',
-    href: '/',
+    href: SITE_PATHS.home,
   },
   {
     id: 2,
     title: 'About',
-    href: '/about',
+    href: SITE_PATHS.about,
   },
   {
     id: 3,
     title: 'Life',
-    href: '/life',
+    href: SITE_PATHS.life,
   },
   {
     id: 4,
     title: 'Tag',
-    href: '/tags',
+    href: SITE_PATHS.tags,
   },
 ]
 


### PR DESCRIPTION
## 작업 내용
- 헤더에서 404로 연결되던 `/life` 경로를 실제 페이지로 추가했습니다.
- 빈 링크였던 개발 카테고리 카드를 실제 태그 페이지로 연결했습니다.
- 공용 라우트 상수를 도입해 헤더와 카테고리 링크를 일관되게 관리하도록 정리했습니다.

## 확인 내용
- npm run build
- 빌드 결과에 `/life` 정적 라우트가 포함되는지 확인
- 최신 main(next-mdx-remote 6.0.0 반영) 기준으로 rebase 후 재검증

## 관련 이슈
- close #6
