### PR TITLE
[#7] 페이지별 SEO 메타데이터와 canonical 추가

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from 'next'
 import AboutPage from '@/src/screens/about/About'
+import { createPageMetadata } from '@/src/shared/config/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+  title: '소개',
+  description: 'Fanta Jin의 소개와 경력, 활동을 정리한 페이지입니다.',
+  path: '/about',
+})
 
 export default function About() {
   return <AboutPage />

--- a/app/blog/(main)/page.tsx
+++ b/app/blog/(main)/page.tsx
@@ -1,5 +1,14 @@
+import type { Metadata } from 'next'
 import { getAllPosts } from '@/src/entities/post/api/post'
 import BlogPage from '@/src/screens/blog/Blog'
+import { createPageMetadata } from '@/src/shared/config/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+  title: '블로그 글 목록',
+  description: 'Fanta Jin 블로그의 전체 글 목록입니다.',
+  path: '/',
+  noIndex: true,
+})
 
 export default async function Page() {
   const posts = await getAllPosts()

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,7 +1,53 @@
-import { getPostBySlug } from '@/src/entities/post/api/post'
+import type { Metadata } from 'next'
+import { getPostBySlug, getPostMetadataBySlug } from '@/src/entities/post/api/post'
 import { PostPageProps } from '@/src/entities/post/model/types'
 import PostDetail from '@/src/screens/blog/post-detail/PostDetail'
 import { notFound } from 'next/navigation'
+import { siteConfig, toAbsoluteUrl } from '@/src/shared/config/metadata'
+
+export async function generateMetadata({
+  params,
+}: PostPageProps): Promise<Metadata> {
+  const resolvedParams = await params
+
+  if (!resolvedParams?.slug) {
+    return {}
+  }
+
+  try {
+    const post = await getPostMetadataBySlug(resolvedParams.slug)
+    const canonicalPath = `/blog/${post.slug}`
+    const image = post.thumbnail || siteConfig.defaultOgImage
+
+    return {
+      title: post.title,
+      description: post.description,
+      keywords: [...post.tags, '개발 블로그', 'Fanta Jin'],
+      alternates: {
+        canonical: canonicalPath,
+      },
+      openGraph: {
+        title: post.title,
+        description: post.description,
+        url: toAbsoluteUrl(canonicalPath),
+        siteName: siteConfig.name,
+        locale: siteConfig.locale,
+        type: 'article',
+        publishedTime: post.date,
+        tags: post.tags,
+        images: [toAbsoluteUrl(image)],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: post.title,
+        description: post.description,
+        images: [toAbsoluteUrl(image)],
+      },
+    }
+  } catch {
+    return {}
+  }
+}
 
 export default async function PostPage({ params }: PostPageProps) {
   const resolvedParams = await params

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Header } from '@/src/widget/header/ui/Header'
 import { ThemeProvider } from '@/src/_app/providers/ThemeContext'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
+import { siteConfig, toAbsoluteUrl } from '@/src/shared/config/metadata'
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
@@ -13,8 +14,35 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
-  title: 'Fanta Jin 블로그',
-  description: 'Fantajin의 개발 블로그입니다.',
+  metadataBase: new URL(siteConfig.siteUrl),
+  title: {
+    default: siteConfig.name,
+    template: `%s | ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+  applicationName: siteConfig.name,
+  authors: [{ name: siteConfig.author }],
+  creator: siteConfig.author,
+  publisher: siteConfig.author,
+  keywords: [...siteConfig.keywords],
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: siteConfig.name,
+    description: siteConfig.description,
+    url: siteConfig.siteUrl,
+    siteName: siteConfig.name,
+    locale: siteConfig.locale,
+    type: 'website',
+    images: [toAbsoluteUrl(siteConfig.defaultOgImage)],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteConfig.name,
+    description: siteConfig.description,
+    images: [toAbsoluteUrl(siteConfig.defaultOgImage)],
+  },
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,14 @@
+import type { Metadata } from 'next'
 import { getAllPosts } from '@/src/entities/post/api/post'
 import BlogPage from '@/src/screens/blog/Blog'
+import { createPageMetadata, siteConfig } from '@/src/shared/config/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+  title: siteConfig.name,
+  description: siteConfig.description,
+  path: '/',
+  absoluteTitle: true,
+})
 
 export default async function Home() {
   const posts = await getAllPosts()

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,7 +1,23 @@
+import type { Metadata } from 'next'
 import { getAllPosts } from '@/src/entities/post/api/post'
 import { TagPageProps } from '@/src/entities/post/model/types'
 import TagList from '@/src/screens/tag/TagList'
 import { notFound } from 'next/navigation'
+import { createPageMetadata } from '@/src/shared/config/metadata'
+
+export async function generateMetadata({
+  params,
+}: TagPageProps): Promise<Metadata> {
+  const { tag } = await params
+  const decodedTag = decodeURIComponent(tag)
+
+  return createPageMetadata({
+    title: `${decodedTag} 태그`,
+    description: `${decodedTag} 태그가 달린 글만 모아볼 수 있는 페이지입니다.`,
+    path: `/tags/${encodeURIComponent(decodedTag)}`,
+    keywords: [decodedTag, '태그', '블로그', 'Fanta Jin'],
+  })
+}
 
 export default async function TagPage({ params }: TagPageProps) {
   const { tag } = await params

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from 'next'
 import { getAllPosts } from '@/src/entities/post/api/post'
 import TagList from '@/src/screens/tag/TagList'
+import { createPageMetadata } from '@/src/shared/config/metadata'
+
+export const metadata: Metadata = createPageMetadata({
+  title: '태그 목록',
+  description: '블로그에 사용된 태그와 주제별 글 모음을 확인할 수 있습니다.',
+  path: '/tags',
+})
 
 export default async function TagsPage() {
   const posts = await getAllPosts()

--- a/src/entities/post/api/post.ts
+++ b/src/entities/post/api/post.ts
@@ -8,44 +8,42 @@ const postsDirectory = path.join(
   'src/entities/post/content/posts',
 )
 
+function readPostFile(slug: string) {
+  const fullPath = path.join(postsDirectory, `${slug}.mdx`)
+  return fs.readFileSync(fullPath, 'utf8')
+}
+
+function parsePostSummary(fileContents: string, slug: string) {
+  const { data } = matter(fileContents)
+
+  return {
+    slug,
+    title: data.title || '',
+    date: data.date || '',
+    description: data.description || '',
+    tags: data.tags || [],
+    thumbnail: data.thumbnail || '',
+  }
+}
+
 // 모든 포스트 가져오기 함수 추가
 export async function getAllPosts() {
-  // 디렉토리에서 모든 파일 이름 가져오기
   const fileNames = fs.readdirSync(postsDirectory)
 
-  // 각 파일에서 데이터 추출
   const allPostsData = await Promise.all(
     fileNames
       .filter((fileName) => fileName.endsWith('.mdx'))
       .map(async (fileName) => {
-        // 파일 이름에서 .mdx 확장자 제거하여 slug 생성
         const slug = fileName.replace(/\.mdx$/, '')
+        const fileContents = fs.readFileSync(
+          path.join(postsDirectory, fileName),
+          'utf8',
+        )
 
-        // 파일 전체 경로
-        const fullPath = path.join(postsDirectory, fileName)
-
-        // 파일 내용 읽기
-        const fileContents = fs.readFileSync(fullPath, 'utf8')
-
-        // gray-matter로 메타데이터 파싱
-        const { data } = matter(fileContents)
-
-        // 타입 안전성을 위한 기본값 설정
-        const post = {
-          slug,
-          title: data.title || '',
-          date: data.date || '',
-          description: data.description || '',
-          tags: data.tags || [],
-          thumbnail: data.thumbnail || '',
-          // content는 블로그 목록에서는 필요 없으므로 제외
-        }
-
-        return post
+        return parsePostSummary(fileContents, slug)
       }),
   )
 
-  // 날짜 기준 내림차순 정렬 (최신 글이 먼저 오도록)
   return allPostsData.sort((a, b) => {
     if (a.date < b.date) {
       return 1
@@ -55,20 +53,17 @@ export async function getAllPosts() {
   })
 }
 
-export async function getPostBySlug(slug: string) {
-  const fullPath = path.join(postsDirectory, `${slug}.mdx`)
-  const fileContents = fs.readFileSync(fullPath, 'utf8')
+export async function getPostMetadataBySlug(slug: string) {
+  return parsePostSummary(readPostFile(slug), slug)
+}
 
-  // 프론트매터와 콘텐츠 분리
-  const { data, content } = matter(fileContents)
+export async function getPostBySlug(slug: string) {
+  const fileContents = readPostFile(slug)
+
+  const { content } = matter(fileContents)
 
   return {
-    slug,
-    title: data.title || '',
-    date: data.date || '',
-    description: data.description || '',
-    tags: data.tags || [],
+    ...parsePostSummary(fileContents, slug),
     content,
-    thumbnail: data.thumbnail || '',
   }
 }

--- a/src/shared/config/metadata.ts
+++ b/src/shared/config/metadata.ts
@@ -1,0 +1,67 @@
+import type { Metadata } from 'next'
+
+const fallbackSiteUrl = 'https://fantajin-blog.vercel.app'
+
+export const siteConfig = {
+  name: 'Fanta Jin 블로그',
+  description: 'Fantajin의 개발 블로그입니다.',
+  author: 'Fanta Jin',
+  locale: 'ko_KR',
+  defaultOgImage: '/logo/Logo.png',
+  keywords: ['Fanta Jin', '프론트엔드', 'Next.js', 'React', '개발 블로그'],
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || fallbackSiteUrl,
+} as const
+
+export function toAbsoluteUrl(path = '/') {
+  return new URL(path, siteConfig.siteUrl).toString()
+}
+
+type MetadataOptions = {
+  title: string
+  description: string
+  path: string
+  image?: string
+  keywords?: string[]
+  noIndex?: boolean
+  absoluteTitle?: boolean
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+  image = siteConfig.defaultOgImage,
+  keywords = [...siteConfig.keywords],
+  noIndex = false,
+  absoluteTitle = false,
+}: MetadataOptions): Metadata {
+  return {
+    title: absoluteTitle ? { absolute: title } : title,
+    description,
+    keywords,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      title,
+      description,
+      url: toAbsoluteUrl(path),
+      siteName: siteConfig.name,
+      locale: siteConfig.locale,
+      type: 'website',
+      images: [toAbsoluteUrl(image)],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [toAbsoluteUrl(image)],
+    },
+    robots: noIndex
+      ? {
+          index: false,
+          follow: true,
+        }
+      : undefined,
+  }
+}


### PR DESCRIPTION
## 작업 내용
- 사이트 공통 메타데이터 헬퍼와 설정을 추가했습니다.
- 홈, 블로그, 소개, 태그, 포스트 페이지에 canonical과 Open Graph/Twitter 메타데이터를 연결했습니다.
- 포스트 메타 생성을 위해 frontmatter 전용 조회 함수를 분리했습니다.
- next-mdx-remote 6.0.0이 반영된 최신 main 기준으로 충돌을 해소했습니다.

## 확인 내용
- npm run build
- 포스트/태그/소개 페이지 메타데이터 생성 코드 확인
- 최신 main(next-mdx-remote 6.0.0 반영) 기준으로 rebase 후 재검증

## 관련 이슈
- close #7
