### PR TITLE
[#8] sitemap, robots.txt, RSS 피드 추가

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,55 @@
+import { getAllPosts } from '@/src/entities/post/api/post'
+import { siteConfig, toAbsoluteUrl } from '@/src/shared/config/site'
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+export async function GET() {
+  const posts = await getAllPosts()
+
+  const items = posts
+    .map((post) => {
+      const postUrl = toAbsoluteUrl(`/blog/${post.slug}`)
+      const categories = post.tags
+        .map((tag: string) => `<category>${escapeXml(tag)}</category>`)
+        .join('')
+
+      return `
+        <item>
+          <title>${escapeXml(post.title)}</title>
+          <link>${postUrl}</link>
+          <guid>${postUrl}</guid>
+          <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+          <description>${escapeXml(post.description)}</description>
+          ${categories}
+        </item>
+      `.trim()
+    })
+    .join('\n')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteConfig.name)}</title>
+    <link>${siteConfig.siteUrl}</link>
+    <description>${escapeXml(siteConfig.description)}</description>
+    <language>ko-KR</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${toAbsoluteUrl('/feed.xml')}" rel="self" type="application/rss+xml" />
+    ${items}
+  </channel>
+</rss>`
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  })
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next'
+import { siteConfig, toAbsoluteUrl } from '@/src/shared/config/site'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    host: siteConfig.siteUrl,
+    sitemap: [toAbsoluteUrl('/sitemap.xml')],
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,57 @@
+import type { MetadataRoute } from 'next'
+import { getAllPosts } from '@/src/entities/post/api/post'
+import { siteConfig, toAbsoluteUrl } from '@/src/shared/config/site'
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPosts()
+  const tags = [...new Set(posts.flatMap((post) => post.tags))].sort()
+  const latestPostDate = posts[0]?.date
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: siteConfig.siteUrl,
+      changeFrequency: 'weekly',
+      priority: 1,
+      lastModified: latestPostDate || new Date().toISOString(),
+    },
+    {
+      url: toAbsoluteUrl('/about'),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: toAbsoluteUrl('/blog'),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+      lastModified: latestPostDate || new Date().toISOString(),
+    },
+    {
+      url: toAbsoluteUrl('/tags'),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+      lastModified: latestPostDate || new Date().toISOString(),
+    },
+    {
+      url: toAbsoluteUrl('/feed.xml'),
+      changeFrequency: 'daily',
+      priority: 0.4,
+      lastModified: latestPostDate || new Date().toISOString(),
+    },
+  ]
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: toAbsoluteUrl(`/blog/${post.slug}`),
+    changeFrequency: 'monthly',
+    priority: 0.9,
+    lastModified: post.date,
+  }))
+
+  const tagRoutes: MetadataRoute.Sitemap = tags.map((tag) => ({
+    url: toAbsoluteUrl(`/tags/${encodeURIComponent(tag)}`),
+    changeFrequency: 'weekly',
+    priority: 0.6,
+    lastModified: latestPostDate || new Date().toISOString(),
+  }))
+
+  return [...staticRoutes, ...postRoutes, ...tagRoutes]
+}

--- a/src/shared/config/site.ts
+++ b/src/shared/config/site.ts
@@ -1,0 +1,9 @@
+export const siteConfig = {
+  name: 'Fanta Jin 블로그',
+  description: 'Fantajin의 개발 블로그입니다.',
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://fantajin-blog.vercel.app',
+} as const
+
+export function toAbsoluteUrl(path = '/') {
+  return new URL(path, siteConfig.siteUrl).toString()
+}


### PR DESCRIPTION
## 작업 내용
- 사이트 URL 설정과 절대 경로 헬퍼를 추가했습니다.
- `sitemap.xml`과 `robots.txt`를 블로그 글/태그 기준으로 생성하도록 구성했습니다.
- `feed.xml` RSS 경로를 추가해 최신 글을 구독할 수 있게 했습니다.

## 확인 내용
- npm run build
- 빌드 결과에 `/sitemap.xml`, `/robots.txt`, `/feed.xml`이 포함되는지 확인
- 최신 main(next-mdx-remote 6.0.0 반영) 기준으로 rebase 후 재검증

## 관련 이슈
- close #8
