### PR TITLE
운영 도메인 기준 메타데이터 URL 정리

### DIFF
--- a/src/shared/config/metadata.ts
+++ b/src/shared/config/metadata.ts
@@ -1,20 +1,5 @@
 import type { Metadata } from 'next'
-
-const fallbackSiteUrl = 'https://fantajin-blog.vercel.app'
-
-export const siteConfig = {
-  name: 'Fanta Jin 블로그',
-  description: 'Fantajin의 개발 블로그입니다.',
-  author: 'Fanta Jin',
-  locale: 'ko_KR',
-  defaultOgImage: '/logo/Logo.png',
-  keywords: ['Fanta Jin', '프론트엔드', 'Next.js', 'React', '개발 블로그'],
-  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || fallbackSiteUrl,
-} as const
-
-export function toAbsoluteUrl(path = '/') {
-  return new URL(path, siteConfig.siteUrl).toString()
-}
+import { siteConfig, toAbsoluteUrl } from './site'
 
 type MetadataOptions = {
   title: string

--- a/src/shared/config/metadata.ts
+++ b/src/shared/config/metadata.ts
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import { siteConfig, toAbsoluteUrl } from './site'
 
+export { siteConfig, toAbsoluteUrl }
+
 type MetadataOptions = {
   title: string
   description: string

--- a/src/shared/config/site.ts
+++ b/src/shared/config/site.ts
@@ -1,7 +1,11 @@
 export const siteConfig = {
   name: 'Fanta Jin 블로그',
   description: 'Fantajin의 개발 블로그입니다.',
-  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://fantajin-blog.vercel.app',
+  author: 'Fanta Jin',
+  locale: 'ko_KR',
+  defaultOgImage: '/logo/Logo.png',
+  keywords: ['Fanta Jin', '프론트엔드', 'Next.js', 'React', '개발 블로그'],
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://www.fantajin.com',
 } as const
 
 export function toAbsoluteUrl(path = '/') {


### PR DESCRIPTION
## 작업 내용
- 사이트 메타 설정을  한 곳으로 모았습니다.
- 이 없을 때도 기본 URL이 을 가리키도록 정리했습니다.
- 기존 import 경로 호환성을 위해  모듈에서 필요한 값을 재export했습니다.

## 확인 사항
- 
> fantajin-blog@0.1.0 lint
> next lint

✔ No ESLint warnings or errors
- 
> fantajin-blog@0.1.0 build
> next build

   ▲ Next.js 15.1.9

   Creating an optimized production build ...
 ✓ Compiled successfully
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/22) ...
   Generating static pages (5/22) 
   Generating static pages (10/22) 
   Generating static pages (16/22) 
 ✓ Generating static pages (22/22)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                              Size     First Load JS
┌ ○ /                                    189 B           114 kB
├ ○ /_not-found                          982 B           106 kB
├ ○ /about                               183 B           114 kB
├ ○ /blog                                189 B           114 kB
├ ƒ /blog/[slug]                         3.16 kB         114 kB
├ ƒ /feed.xml                            134 B           105 kB
├ ○ /life                                189 B           114 kB
├ ○ /robots.txt                          0 B                0 B
├ ○ /sitemap.xml                         0 B                0 B
├ ○ /tags                                1.46 kB         125 kB
└ ● /tags/[tag]                          1.46 kB         125 kB
    ├ /tags/회고
    ├ /tags/커리어
    ├ /tags/개발
    └ [+7 more paths]
+ First Load JS shared by all            105 kB
  ├ chunks/4bd1b696-5137e7b1aa00ddaa.js  53 kB
  ├ chunks/517-60a3a77d73ec6957.js       50.5 kB
  └ other shared chunks (total)          1.91 kB


○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand

## 기대 효과
- canonical, Open Graph, Twitter, RSS 등에서 운영 도메인과 실제 배포 주소가 어긋나는 문제를 줄일 수 있습니다.