### PR TITLE
RSS와 sitemap 한글 slug URL 인코딩 보강

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
 
   const items = posts
     .map((post) => {
-      const postUrl = toAbsoluteUrl(`/blog/${post.slug}`)
+      const postUrl = toAbsoluteUrl(`/blog/${encodeURIComponent(post.slug)}`)
       const categories = post.tags
         .map((tag: string) => `<category>${escapeXml(tag)}</category>`)
         .join('')

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -40,7 +40,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: toAbsoluteUrl(`/blog/${post.slug}`),
+    url: toAbsoluteUrl(`/blog/${encodeURIComponent(post.slug)}`),
     changeFrequency: 'monthly',
     priority: 0.9,
     lastModified: post.date,


### PR DESCRIPTION
## 작업 내용
- RSS 피드에서 포스트 링크와 guid를 생성할 때 slug를 URL 인코딩하도록 수정했습니다.
- sitemap에서 포스트 상세 경로를 생성할 때도 같은 방식으로 slug를 인코딩하도록 맞췄습니다.

## 확인 사항
- `npm run lint`
- `npm run build`
- 로컬 `feed.xml`, `sitemap.xml`에서 한글 slug가 인코딩된 URL로 출력되는 것 확인

## 기대 효과
- 한글 제목 기반 slug를 사용하는 글도 RSS 리더, 검색엔진, 크롤러에서 더 안정적으로 처리할 수 있습니다.
